### PR TITLE
feat(typings): make stricter `error` type declaration

### DIFF
--- a/lib/exports.d.ts
+++ b/lib/exports.d.ts
@@ -11,7 +11,7 @@ export declare class ValueError extends TypeError {
 export declare class BlorkError extends ValueError {}
 
 // Functions.
-export declare function check(value: any, type: string, error?: Function): void;
+export declare function check(value: any, type: string, error?: typeof ValueError | { new (message: string): any }): void;
 export declare function checker(type: string): BlorkChecker;
 export declare function add(name: string, checker: string | BlorkChecker, description?: string): void;
 export declare function debug(value: any): string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4016,9 +4016,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-			"integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+			"integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
 		"url": "git://github.com/dhoulb/blork.git"
 	},
 	"devDependencies": {
-		"eslint": "^7.0.0",
-		"eslint-config-prettier": "^7.0.0",
-		"eslint-plugin-prettier": "^3.0.0",
-		"jest": "^26.0.1",
-		"prettier": "^2.0.5"
+		"eslint": "^7.18.0",
+		"eslint-config-prettier": "^7.2.0",
+		"eslint-plugin-prettier": "^3.3.1",
+		"jest": "^26.6.3",
+		"prettier": "^2.2.1"
 	},
 	"scripts": {
 		"fix": "eslint --fix ./",

--- a/test/checkers/checkers.test.js
+++ b/test/checkers/checkers.test.js
@@ -93,7 +93,7 @@ describe("checkers", () => {
 		expect(mockCheck(circular, "circular")).toBe(undefined);
 		expect(mockCheck([], "array")).toBe(undefined);
 		expect(mockCheck([], "arr")).toBe(undefined);
-		expect(mockCheck({ "0": "abc", length: 1 }, "arraylike")).toBe(undefined);
+		expect(mockCheck({ "0": "abc", length: 1 }, "arraylike")).toBe(undefined); // prettier-ignore
 		expect(mockCheck({ length: 0 }, "arguments")).toBe(undefined);
 		expect(mockCheck({ length: 0 }, "args")).toBe(undefined);
 		expect(mockCheck(new Date(), "date")).toBe(undefined);


### PR DESCRIPTION
@dhoulb,
Hi, Dave,

Let's describe `error` argument to make it clear that this is a constructor, not a factory.